### PR TITLE
R CMD check fix where subdir slot is character(0)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: switchr
 Type: Package
 Title: Installing, Managing, and Switching Between Distinct Sets of
     Installed Packages
-Version: 0.11.4.2
+Version: 0.11.4.3
 Author: Gabriel Becker[aut, cre]
 Maintainer: Gabriel Becker <becker.gabriel@gene.com>
 Copyright: Genentech Inc

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-Changes in version 0.11.4.2 (2017-05-24)
+Changes in version 0.11.4.3 (2017-05-30)
 -------------------------
 
 Bugfixes

--- a/R/makePkgSourceDir-methods.R
+++ b/R/makePkgSourceDir-methods.R
@@ -95,6 +95,9 @@ setMethod("makePkgDir", c(name = "ANY", source = "GitSource"), function(name, so
     if (!is.null(oldwd))
         on.exit(setwd(oldwd)) else warning("working directory returned as NULL, unable to reset it after creating pkg directory")
     sdir = location(source)
+    if(identical(source@subdir, character(0))) {
+        source@subdir <- "."
+    }
     if (file.exists(name) && file.exists(file.path(name, ".git"))
         && file.exists(file.path(name, source@subdir, "DESCRIPTION"))) {
         logfun(param)(name, "Existing temporary checkout found at this location. Updating")


### PR DESCRIPTION
R CMD check was failing while looking for the subdir slot in the 'source' S4 object. The value being displayed for this slot was character(0). Now, if that slot's value defaults to character(0), I'm setting it to ".". This resolved the R CMD check error.