### PR TITLE
Don't shallow clone

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: switchr
 Type: Package
 Title: Installing, Managing, and Switching Between Distinct Sets of
     Installed Packages
-Version: 0.12.6.2
+Version: 0.12.6.3
 Author: Gabriel Becker[aut, cre]
 Maintainer: Gabriel Becker <becker.gabriel@gene.com>
 Copyright: Genentech Inc

--- a/R/makePkgSourceDir-methods.R
+++ b/R/makePkgSourceDir-methods.R
@@ -104,12 +104,7 @@ setMethod("makePkgDir", c(name = "ANY", source = "GitSource"), function(name, so
             logfun(param)(name, ".git dir & DESCRIPTION file missing. Deleting src dir")
             unlink(name, recursive = TRUE)
         }
-        if (latest_only) {
-            logfun(param)(name, "Cloning only latest commit for package")
-            args = c("clone --depth 1", sdir, name)
-        } else {
-            args = c("clone", sdir, name)
-        }
+        args = c("clone", sdir, name)
         res = tryCatch(system_w_init("git", args = args, intern = TRUE, param = param),
             error = function(x) x)
         if (is(res, "error") || (!is.null(attr(res, "status")) && attr(res, "status") >


### PR DESCRIPTION
This causes issues while attempting to checkout a specific branch. Shallow cloning does not checkout all branches.