### PR TITLE
add .removePkg() helper

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: switchr
 Type: Package
 Title: Installing, Managing, and Switching Between Distinct Sets of
     Installed Packages
-Version: 0.13.4.1
+Version: 0.13.6
 Author: Gabriel Becker[aut, cre]
 Maintainer: Gabriel Becker <gabembecker@gmail.com>
 Copyright: Genentech Inc

--- a/R/Utilities.R
+++ b/R/Utilities.R
@@ -701,3 +701,30 @@ noVignettesArg = function() {
 
     
 ## }
+
+## Remove a package from a GRANRepository object.
+.removePkg <- function(repo, package) {
+    not_found <- TRUE 
+    ## pkg_manifest and pkg_version
+    pm <- manifest_df(repo)
+    if (package %in% pm$name) {
+        manifest_df(repo) <- pm[pm$name != package,]
+        not_found <- FALSE 
+    }
+    pv <- versions_df(manifest(repo))
+    if (package %in% pv$name) {
+        versions_df(manifest(repo)) <- pv[pv$name != package,]
+        not_found <- FALSE 
+    }
+    ## results
+    res <- repo_results(repo)
+    if (package %in% res$name) { 
+        repo_results(repo) <- res[res$name != package,]
+        not_found <- FALSE 
+    }
+
+    if (not_found)
+        message(paste0("'", package, "' not found in repo object"))
+
+    repo
+}

--- a/R/Utilities.R
+++ b/R/Utilities.R
@@ -722,6 +722,12 @@ noVignettesArg = function() {
         repo_results(repo) <- res[res$name != package,]
         not_found <- FALSE 
     }
+    ## suspended
+    suspended <- suspended_pkgs(repo)
+    if (package %in% suspended) { 
+        suspended_pkgs(repo) <- suspended[suspended != package]
+        not_found <- FALSE
+    } 
 
     if (not_found)
         message(paste0("'", package, "' not found in repo object"))


### PR DESCRIPTION
This pull request adds a helper function that removes a package from a GRANRepository object. Intended as a sister function to addPkg() using primarily during testing to remove test packages. Not exported.

When removing a package from a GRANRepository object that has gone through a build cycle should we also remove old build products or run clear_repo()?